### PR TITLE
Fix travis build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,11 @@ before_script:
   - sleep 15
   - npm install -g bower grunt-cli
   - bower install
-services: mongodb
+services:
+- mongodb
+addons:
+  apt:
+    sources:
+    - mongodb-3.0-precise
+    packages:
+    - mongodb-org-server

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -625,45 +625,11 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('test', function (target) {
-        if (target === 'server') {
-            return grunt.task.run([
-                'env:all',
-                'env:test',
-                'mochaTest'
-            ]);
-        }
-
-        else if (target === 'client') {
-            return grunt.task.run([
-                'clean:server',
-                'env:all',
-                'injector:less',
-                'concurrent:test',
-                'injector',
-                'autoprefixer',
-                'karma'
-            ]);
-        }
-
-        else if (target === 'e2e') {
-            return grunt.task.run([
-                'clean:server',
-                'env:all',
-                'env:test',
-                'injector:less',
-                'concurrent:test',
-                'injector',
-                'wiredep',
-                'autoprefixer',
-                'express:dev',
-                'protractor'
-            ]);
-        }
-
-        else grunt.task.run([
-                'test:server',
-                'test:client'
-            ]);
+      return grunt.task.run([
+        'env:all',
+        'env:test',
+        'mochaTest'
+      ]);
     });
 
     grunt.registerTask('build', [


### PR DESCRIPTION
Travis uses mongo 3. This fixes problems with some features that were unsupported in mongo 2.4, the default mongo version of travis.

Removed unused tests, especially client tests.
